### PR TITLE
Rayt 29 creation de scenes material

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,5 @@ raytracer
 # End of https://www.toptal.com/developers/gitignore/api/cmake
 
 .vscode/
+build.ninja
+.cmake/

--- a/src/Raytracer/Core/FactoryMaterial.cpp
+++ b/src/Raytracer/Core/FactoryMaterial.cpp
@@ -19,7 +19,7 @@ Raytracer::IMaterial &Raytracer::FactoryMaterial::createMaterial(const std::stri
     return (*result);
 }
 
-void Raytracer::FactoryMaterial::destroyMaterial(Raytracer::IMaterial &material)
+void Raytracer::FactoryMaterial::destroyMaterial(const Raytracer::IMaterial &material)
 {
     Raytracer::AMaterial *mat = static_cast<Raytracer::AMaterial *>(&material);
 

--- a/src/Raytracer/Core/FactoryMaterial.cpp
+++ b/src/Raytracer/Core/FactoryMaterial.cpp
@@ -14,21 +14,21 @@ Raytracer::FactoryMaterial &Raytracer::FactoryMaterial::getInstance()
     return (instance);
 }
 
-Raytracer::IMaterial &Raytracer::FactoryMaterial::createMaterial(const std::string &name, libconfig::Setting &data)
+Raytracer::IMaterial *Raytracer::FactoryMaterial::createMaterial(const std::string &name, const libconfig::Setting &data)
 {
     Raytracer::IMaterial *result = _materials[name].first(data);
 
     if (result == nullptr) {
         //throw
     }
-    return (*result);
+    return (result);
 }
 
-void Raytracer::FactoryMaterial::destroyMaterial(const Raytracer::IMaterial &material)
+void Raytracer::FactoryMaterial::destroyMaterial(Raytracer::IMaterial *material)
 {
-    Raytracer::AMaterial *mat = static_cast<Raytracer::AMaterial *>(&material);
+    Raytracer::AMaterial *mat = static_cast<Raytracer::AMaterial *>(material);
 
-    _materials[mat->getType()].second(&material);
+    _materials[mat->getType()].second(material);
 }
 
 void Raytracer::FactoryMaterial::addCreator(

--- a/src/Raytracer/Core/FactoryMaterial.hpp
+++ b/src/Raytracer/Core/FactoryMaterial.hpp
@@ -21,8 +21,8 @@ namespace Raytracer {
         FactoryMaterial(const FactoryMaterial&) = delete;
         FactoryMaterial& operator=(const FactoryMaterial&) = delete;
         static FactoryMaterial& getInstance();
-        Raytracer::IMaterial &createMaterial(const std::string &name, libconfig::Setting &);
-        void destroyMaterial(Raytracer::IMaterial &material);
+        Raytracer::IMaterial *createMaterial(const std::string &name, const libconfig::Setting &);
+        void destroyMaterial(Raytracer::IMaterial *material);
         void addCreator(const std::string &name, std::function<Raytracer::IMaterial *(const libconfig::Setting &)> funcCreate, std::function<void(Raytracer::IMaterial *material)> funcDestroy);
         [[nodiscard]] const std::map<std::string, std::pair<std::function<Raytracer::IMaterial *(const libconfig::Setting &)>, std::function<void(Raytracer::IMaterial *material)>>>& getMaterials() const;
 

--- a/src/Raytracer/Core/FactoryMaterial.hpp
+++ b/src/Raytracer/Core/FactoryMaterial.hpp
@@ -21,7 +21,7 @@ namespace Raytracer {
 
             ~FactoryMaterial() = default;
 
-            Raytracer::IMaterial &createMaterial(const std::string &name, libconfig::Setting &);
+            Raytracer::IMaterial &createMaterial(const std::string &name, const libconfig::Setting &);
 
             void destroyMaterial(Raytracer::IMaterial &material);
 

--- a/src/Raytracer/Core/LoadConfig.cpp
+++ b/src/Raytracer/Core/LoadConfig.cpp
@@ -7,17 +7,43 @@
 
 #include <iostream>
 #include <filesystem>
+#include <vector>
+#include "IEntity.hpp"
 #include "LoadConfig.hpp"
 
-static const std::map<std::string, std::shared_ptr<Raytracer::FactoryEntity>> Factories = {
-    {PRIMITIVES, std::make_shared<Raytracer::FactoryEntity>()},
-    {CAMERA, std::make_shared<Raytracer::FactoryEntity>()},
-    {LIGHTS, std::make_shared<Raytracer::FactoryEntity>()}
+static const std::string FOLDER_NAME = "Scenes";
+
+static const std::string PRIMITIVES = "primitives";
+static const std::string CAMERA = "camera";
+static const std::string LIGHTS = "lights";
+static const std::string MATERIALS = "materials";
+
+static const std::vector<std::string> elementTypes = {
+    PRIMITIVES,
+    CAMERA,
+    LIGHTS,
+    MATERIALS
 };
 
 Raytracer::LoadConfig::LoadConfig()
 {
     loadConfigFolder();
+}
+
+bool Raytracer::LoadConfig::isAGoodConfigFile(libconfig::Config &cfg, const std::string &path)
+{
+    try {
+        cfg.readFile(path.c_str());
+        std::cout << "File found : " << path << std::endl;
+    } catch (const libconfig::FileIOException &fioex) {
+        std::cerr << "I/O error while reading file." << std::endl;
+        return false;
+    } catch (const libconfig::ParseException &pex) {
+        std::cerr << "Parse error at " << pex.getFile() << ":" << pex.getLine()
+                  << " - " << pex.getError() << std::endl;
+        return false;
+    }
+    return true;
 }
 
 void Raytracer::LoadConfig::loadConfigFolder()
@@ -30,56 +56,47 @@ void Raytracer::LoadConfig::loadConfigFolder()
     }
 }
 
-void Raytracer::LoadConfig::loadConfigFile(const std::string &path)
+void Raytracer::LoadConfig::loadPluginType(const std::string &type, const libconfig::Setting &root, Raytracer::Scene &scene)
+{
+    if (type == PRIMITIVES)
+        loadPrimitives(root);
+    else if (type == MATERIALS)
+        loadMaterials(root);
+    else if (std::find(elementTypes.begin(), elementTypes.end(), type) != elementTypes.end())
+        _factoryEntity.createEntity(type, root);
+    else
+        std::cerr << "configLoader: loadPlugintypes: plugin type not found" << std::endl;
+}
+
+std::unique_ptr<Raytracer::Scene> Raytracer::LoadConfig::loadConfigFile(const std::string &path)
 {
     libconfig::Config cfg;
+    std::unique_ptr<Raytracer::Scene> scene = std::make_unique<Raytracer::Scene>();
 
-    try {
-        cfg.readFile(path.c_str());
-        std::cout << "File found : " << path << std::endl;
-    } catch (const libconfig::FileIOException &fioex) {
-        std::cerr << "I/O error while reading file." << std::endl;
-        return;
-    } catch (const libconfig::ParseException &pex) {
-        std::cerr << "Parse error at " << pex.getFile() << ":" << pex.getLine()
-                  << " - " << pex.getError() << std::endl;
-        return;
-    }
+    if (!isAGoodConfigFile(cfg, path))
+        return nullptr;
     const libconfig::Setting &root = cfg.getRoot();
     // Output a list of all books in the inventory.
     try {
-        const libconfig::Setting &books = root;
-        int count = books.getLength();
+        const libconfig::Setting &elements = root;
+        int count = elements.getLength();
 
         for (int i = 0; i < count; i++) {
-            const libconfig::Setting &book = books[i];
-            std::cout << book.getName() << std::endl << std::endl;
+            const libconfig::Setting &element = elements[i];
 
-            if (book.getName() == PRIMITIVES)
-                loadPrimitives(book);
-            else
-                loadPluginType(book.getName(), book);
+            std::cout << element.getName() << std::endl << std::endl;
+            loadPluginType(element.getName(), element, *scene);
         }
     } catch (const libconfig::SettingNotFoundException &nfex) {
         // Ignore.
     }
+    return scene;
 }
 
-void Raytracer::LoadConfig::loadPluginType(const std::string &type, const libconfig::Setting &root)
+std::vector<Raytracer::IEntity *> Raytracer::LoadConfig::loadPrimitives(const libconfig::Setting &root)
 {
-    if (Factories.find(type) == Factories.end()) {
-        std::cerr << "configLoader: loadPlugintypes: plugin type not found" << std::endl;
-        return;
-    }
-    Factories.find(type)->second->createEntity(type, root);
-}
+    std::vector<Raytracer::IEntity *> primitivesEntities;
 
-void Raytracer::LoadConfig::loadPrimitives(const libconfig::Setting &root)
-{
-    if (Factories.find(PRIMITIVES) == Factories.end()) {
-        std::cerr << "configLoader: loadPrimitives: plugin type not found" << std::endl;
-        return;
-    }
     try {
         const libconfig::Setting &primitives = root[PRIMITIVES];
         int count = primitives.getLength();
@@ -87,7 +104,24 @@ void Raytracer::LoadConfig::loadPrimitives(const libconfig::Setting &root)
         for (int i = 0; i < count; i++) {
             const libconfig::Setting &primitive = primitives[i];
             std::cout << primitive.getName() << std::endl << std::endl;
-            Factories.find(PRIMITIVES)->second->createEntity(primitive.getName(), primitive);
+            _factoryEntity.createEntity(primitive.getName(), primitive);
+        }
+    } catch (const libconfig::SettingNotFoundException &nfex) {
+        // Ignore.
+    }
+    return primitivesEntities;
+}
+
+void Raytracer::LoadConfig::loadMaterials(const libconfig::Setting &root)
+{
+    try {
+        const libconfig::Setting &materials = root[MATERIALS];
+        int count = materials.getLength();
+
+        for (int i = 0; i < count; i++) {
+            const libconfig::Setting &material = materials[i];
+            std::cout << material.getName() << std::endl << std::endl;
+            _factoryMaterial.createMaterial(material.getName(), material);
         }
     } catch (const libconfig::SettingNotFoundException &nfex) {
         // Ignore.

--- a/src/Raytracer/Core/LoadConfig.hpp
+++ b/src/Raytracer/Core/LoadConfig.hpp
@@ -10,14 +10,12 @@
 #include <string>
 #include <memory>
 #include <map>
+#include <cstdbool>
+#include <functional>
 #include <libconfig.h++>
+#include "Scene.hpp"
 #include "FactoryEntity.hpp"
-
-static const std::string FOLDER_NAME = "Scenes";
-
-static const std::string PRIMITIVES = "primitives";
-static const std::string CAMERA = "camera";
-static const std::string LIGHTS = "lights";
+#include "FactoryMaterial.hpp"
 
 namespace Raytracer {
     class LoadConfig {
@@ -26,11 +24,14 @@ namespace Raytracer {
             ~LoadConfig() = default;
 
             void loadConfigFolder();
-            static void loadConfigFile(const std::string &path);
+            static std::unique_ptr<Raytracer::Scene> loadConfigFile(const std::string &path);
         protected:
         private:
-            static void loadPluginType(const std::string &type, const libconfig::Setting &root);
-            static void loadPrimitives(const libconfig::Setting &root);
-
+            static void loadPluginType(const std::string &type, const libconfig::Setting &root, Raytracer::Scene &scene);
+            static std::vector<Raytracer::IEntity *> loadPrimitives(const libconfig::Setting &root);
+            static void loadMaterials(const libconfig::Setting &root);
+            static bool isAGoodConfigFile(libconfig::Config &cfg, const std::string &path);
+            static Raytracer::FactoryEntity _factoryEntity;
+            static Raytracer::FactoryMaterial _factoryMaterial;
     };
 }; // namespace Raytracer

--- a/src/Raytracer/Core/LoadConfig.hpp
+++ b/src/Raytracer/Core/LoadConfig.hpp
@@ -23,15 +23,15 @@ namespace Raytracer {
             LoadConfig();
             ~LoadConfig() = default;
 
-            void loadConfigFolder();
+            std::vector<std::unique_ptr<Raytracer::Scene>> loadConfigFolder();
             static std::unique_ptr<Raytracer::Scene> loadConfigFile(const std::string &path);
         protected:
         private:
-            static void loadPluginType(const std::string &type, const libconfig::Setting &root, Raytracer::Scene &scene);
-            static std::vector<Raytracer::IEntity *> loadPrimitives(const libconfig::Setting &root);
-            static void loadMaterials(const libconfig::Setting &root);
+            static void loadPluginType(const std::string &type, const libconfig::Setting &root, Raytracer::Scene &scene, std::map<std::string, std::string> &materialsToApply);
+            static void loadPrimitives(const libconfig::Setting &root, Raytracer::Scene &scene, std::map<std::string, std::string> &materialsToApply);
+            static void loadMaterials(const libconfig::Setting &root, Raytracer::Scene &scene);
             static bool isAGoodConfigFile(libconfig::Config &cfg, const std::string &path);
-            static Raytracer::FactoryEntity _factoryEntity;
-            static Raytracer::FactoryMaterial _factoryMaterial;
+            static void applyMaterialsToPrimitives(Raytracer::Scene &scene, std::map<std::string, std::string> &materialsToApply);
+            static Raytracer::IMaterial *getMaterialFromName(const Raytracer::Scene &scene, const std::string &name);
     };
 }; // namespace Raytracer

--- a/src/Raytracer/Entity/APrimitive.cpp
+++ b/src/Raytracer/Entity/APrimitive.cpp
@@ -20,9 +20,11 @@ float Raytracer::APrimitive::intersect(const Ray &ray) const
     return 0;
 }
 
-void Raytracer::APrimitive::setMaterial(std::unique_ptr<IMaterial> material)
+void Raytracer::APrimitive::setMaterial(IMaterial *material)
 {
-    _material = std::move(material);
+    if (_material == nullptr)
+        return;
+    _material = material;
 }
 
 Component::Vector3f Raytracer::APrimitive::getNormal(const Component::Vector3f &hit_point) const

--- a/src/Raytracer/Entity/APrimitive.hpp
+++ b/src/Raytracer/Entity/APrimitive.hpp
@@ -20,7 +20,7 @@ namespace Raytracer {
 
         [[nodiscard]] float intersect(const Ray &ray) const override;
 
-        void setMaterial(std::unique_ptr<IMaterial> material) override;
+        void setMaterial(IMaterial *material) override;
 
         [[nodiscard]] Component::Vector3f getNormal(const Component::Vector3f &hit_point) const override;
 
@@ -33,6 +33,6 @@ namespace Raytracer {
     protected:
     private:
         std::string _typePrimitive;
-        std::unique_ptr<IMaterial> _material;
+        IMaterial *_material;
     };
 };

--- a/src/Raytracer/Entity/IMaterial.hpp
+++ b/src/Raytracer/Entity/IMaterial.hpp
@@ -5,6 +5,8 @@
 ** IMaterial
 */
 
+#pragma once
+
 #include "Color.hpp"
 #include "Vector3f.hpp"
 

--- a/src/Raytracer/Entity/IPrimitive.hpp
+++ b/src/Raytracer/Entity/IPrimitive.hpp
@@ -20,7 +20,7 @@ namespace Raytracer {
 
         virtual float intersect(const Ray &ray) const = 0 ;
 
-        virtual void setMaterial(std::unique_ptr<IMaterial> material) = 0;
+        virtual void setMaterial(IMaterial *material) = 0;
 
         [[nodiscard]] virtual Component::Vector3f getNormal(const Component::Vector3f &hit_point) const = 0;
 

--- a/src/Raytracer/Entity/Scene.cpp
+++ b/src/Raytracer/Entity/Scene.cpp
@@ -26,11 +26,33 @@ void Raytracer::Scene::addEntity(IEntity *entity)
     _entities.push_back(entity);
 }
 
+void Raytracer::Scene::addMaterial(IMaterial *material)
+{
+    _materials.push_back(material);
+}
+
 Raytracer::IEntity &Raytracer::Scene::getEntity(int index) const
 {
     if (index < 0 || index >= _entities.size())
         throw std::out_of_range("Index out of range");
     return *_entities[index];
+}
+
+const std::vector<Raytracer::IEntity *> &Raytracer::Scene::getEntities() const
+{
+    return _entities;
+}
+
+Raytracer::IMaterial &Raytracer::Scene::getMaterial(int index) const
+{
+    if (index < 0 || index >= _materials.size())
+        throw std::out_of_range("Index out of range");
+    return *_materials[index];
+}
+
+const std::vector<Raytracer::IMaterial *> &Raytracer::Scene::getMaterials() const
+{
+    return _materials;
 }
 
 Raytracer::Image &Raytracer::Scene::getImage() const

--- a/src/Raytracer/Entity/Scene.hpp
+++ b/src/Raytracer/Entity/Scene.hpp
@@ -23,7 +23,15 @@ namespace Raytracer {
 
         void addEntity(IEntity *entity);
 
+        void addMaterial(IMaterial *material);
+
         [[nodiscard]] IEntity &getEntity(int index) const;
+
+        [[nodiscard]] const std::vector<IEntity *> &getEntities() const;
+
+        [[nodiscard]] IMaterial &getMaterial(int index) const;
+
+        [[nodiscard]] const std::vector<IMaterial *> &getMaterials() const;
 
         void calculateImage();
 
@@ -34,6 +42,7 @@ namespace Raytracer {
     protected:
     private:
         std::vector<IEntity *> _entities;
+        std::vector<IMaterial *> _materials;
         std::unique_ptr<Image> _image;
     };
 };


### PR DESCRIPTION
J'ai changé la factory material parce que c'était des références contrairement aux entities alors que ca fait la meme chose, et pour certaines fonctions ca prenait des pointeurs.

Et j'ai rajouté des getters et setter pour pouvoir manipuler les materiaux de ma scene.